### PR TITLE
Updated DOUBAN_API_KEY

### DIFF
--- a/src/calibre/ebooks/metadata/sources/douban.py
+++ b/src/calibre/ebooks/metadata/sources/douban.py
@@ -65,7 +65,7 @@ class Douban(Source):
     supports_gzip_transfer_encoding = True
     cached_cover_url_is_reliable = True
 
-    DOUBAN_API_KEY = '0df993c66c0c636e29ecbb5344252a4a'
+    DOUBAN_API_KEY = '054022eaeae0b00e0fc068c0c0a2102a'
     DOUBAN_API_URL = 'https://api.douban.com/v2/book/search'
     DOUBAN_BOOK_URL = 'https://book.douban.com/subject/%s/'
 


### PR DESCRIPTION
The original apikey (`0df993c66c0c636e29ecbb5344252a4a`) has been banned for a while. Detailed discussion can be found [here](https://www.v2ex.com/t/699393).
The new one (`054022eaeae0b00e0fc068c0c0a2102a`) is valid in my curl tests.

Please check the validity of a new build though.

Thanks for your efforts. 😀